### PR TITLE
Added API Version for Reference Func in App Service and Removed Certificate App Setting

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -183,10 +183,6 @@
                             {
                                 "name": "ASPNETCORE_ENVIRONMENT",
                                 "value": "[toUpper(parameters('environmentFullName'))]"
-                            },
-                            {
-                                "name": "WEBSITE_LOAD_CERTIFICATES",
-                                "value": "[reference('app-service-certificate').outputs.certificateThumbprint.value]"
                             }
                         ]
                     },
@@ -203,7 +199,7 @@
                         "value": "[parameters('customHostName')]"
                     },
                     "certificateThumbprint": {
-                        "value": "[if(greater(length(parameters('customHostname')), 0), reference('app-service-certificate').outputs.certificateThumbprint.value, '')]"
+                        "value": "[if(greater(length(parameters('customHostname')), 0), reference('app-service-certificate', '2018-11-01').outputs.certificateThumbprint.value, '')]"
                     }
                 }
             },


### PR DESCRIPTION
Following amendments have been made to the ARM template:

1. Added the API version to the reference function in the app service deployment to resolve VSTS release error. 
2. Removed WEBSITE_LOAD_CERTIFICATES app setting from app service as code doesn't use it.