### PR TITLE
Changed environmentFullName to environmentName to Consolidate VSTS Variables

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "environmentFullName": {
+        "environmentName": {
             "type": "string",
             "metadata": {
                 "description": "The name of the environment."
@@ -170,7 +170,7 @@
                         "value": [
                             {
                                 "name": "EnvironmentName",
-                                "value": "[parameters('environmentFullName')]"
+                                "value": "[parameters('environmentName')]"
                             },
                             {
                                 "name": "ConfigurationStorageConnectionString",
@@ -182,7 +182,7 @@
                             },
                             {
                                 "name": "ASPNETCORE_ENVIRONMENT",
-                                "value": "[toUpper(parameters('environmentFullName'))]"
+                                "value": "[toUpper(parameters('environmentName'))]"
                             }
                         ]
                     },


### PR DESCRIPTION
I've changed the environmentFullName to environmentName parameter in the ARM template to consolidate the amount of release pipeline variables. 