### PR TITLE
CON-2519 allow employer to enter new start date

### DIFF
--- a/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Controllers/ApprenticeControllerTests/WhenPostingWhatIsTheNewStartDateTests.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Controllers/ApprenticeControllerTests/WhenPostingWhatIsTheNewStartDateTests.cs
@@ -1,0 +1,85 @@
+﻿using AutoFixture;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.CommitmentsV2.Api.Client;
+using SFA.DAS.CommitmentsV2.Shared.Interfaces;
+using SFA.DAS.EmployerCommitmentsV2.Web.Controllers;
+using SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice;
+using SFA.DAS.EmployerCommitmentsV2.Web.RouteValues;
+using SFA.DAS.EmployerUrlHelper;
+
+namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Controllers.ApprenticeControllerTests
+{
+    public class WhenPostingWhatIsTheNewStartDateTests
+    {
+        private Fixture _autoFixture;
+        private WhenPostingWhatIsTheNewStartDateTestFixture _fixture;
+
+        private WhatIsTheNewStartDateViewModel _viewModel
+
+        [SetUp]
+        public void Arrange()
+        {
+            _autoFixture = new Fixture();
+
+            _viewModel = _autoFixture.Build<WhatIsTheNewStartDateViewModel>().Create();
+
+            _fixture = new WhenPostingWhatIsTheNewStartDateTestFixture();
+        }
+
+        [Test]
+        public void ThenRedirectToTheWhatIsTheNewStopDatePage()
+        {
+            _viewModel.Edit = null;
+
+            var result = _fixture.WhatIsTheNewStartDate(_viewModel);
+
+            _fixture.VerifyRedirectsToTheWhatIsTheNewStopDatePage(result);
+        }
+
+        [Test]
+        public void AndUserIsChangingTheirAnswer_ThenRedirectToTheConfirmationPage()
+        {
+            _viewModel.Edit = true;
+
+            var result = _fixture.WhatIsTheNewStartDate(_viewModel);
+
+            _fixture.VerifyRedirectsBackToConfirmDetailsAndSendRequestPage(result);
+        }
+    }
+
+    public class WhenPostingWhatIsTheNewStartDateTestFixture
+    {
+        private readonly ApprenticeController _controller;
+
+        public WhenPostingWhatIsTheNewStartDateTestFixture()
+        {
+            _controller = new ApprenticeController(Mock.Of<IModelMapper>(),
+               Mock.Of<ICookieStorageService<IndexRequest>>(),
+               Mock.Of<ICommitmentsApiClient>(),
+               Mock.Of<ILinkGenerator>(),
+               Mock.Of<ILogger<ApprenticeController>>());
+        }
+
+        public IActionResult WhatIsTheNewStartDate(WhatIsTheNewStartDateViewModel viewModel)
+        {
+            return _controller.WhatIsTheNewStartDate(viewModel);
+        }
+
+        public void VerifyRedirectsToTheWhatIsTheNewStopDatePage(IActionResult result)
+        {
+            var redirectResult = (RedirectToRouteResult)result;
+
+            Assert.AreEqual(RouteNames.WhatIsTheNewStopDate, redirectResult.RouteName);
+        }
+
+        public void VerifyRedirectsBackToConfirmDetailsAndSendRequestPage(IActionResult result)
+        {
+            var redirectResult = (RedirectToRouteResult)result;
+
+            Assert.AreEqual(RouteNames.ConfirmDetailsAndSendRequest, redirectResult.RouteName);
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Controllers/ApprenticeControllerTests/WhenPostingWhatIsTheNewStartDateTests.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Controllers/ApprenticeControllerTests/WhenPostingWhatIsTheNewStartDateTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
+using SFA.DAS.Authorization.Services;
 using SFA.DAS.CommitmentsV2.Api.Client;
 using SFA.DAS.CommitmentsV2.Shared.Interfaces;
 using SFA.DAS.EmployerCommitmentsV2.Web.Controllers;
@@ -17,7 +18,7 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Controllers.ApprenticeCont
         private Fixture _autoFixture;
         private WhenPostingWhatIsTheNewStartDateTestFixture _fixture;
 
-        private WhatIsTheNewStartDateViewModel _viewModel
+        private WhatIsTheNewStartDateViewModel _viewModel;
 
         [SetUp]
         public void Arrange()
@@ -32,11 +33,11 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Controllers.ApprenticeCont
         [Test]
         public void ThenRedirectToTheWhatIsTheNewStopDatePage()
         {
-            _viewModel.Edit = null;
+            _viewModel.Edit = false;
 
             var result = _fixture.WhatIsTheNewStartDate(_viewModel);
 
-            _fixture.VerifyRedirectsToTheWhatIsTheNewStopDatePage(result);
+            _fixture.VerifyRedirectsToTheWhatIsTheNewEndDatePage(result as RedirectToRouteResult);
         }
 
         [Test]
@@ -46,7 +47,7 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Controllers.ApprenticeCont
 
             var result = _fixture.WhatIsTheNewStartDate(_viewModel);
 
-            _fixture.VerifyRedirectsBackToConfirmDetailsAndSendRequestPage(result);
+            _fixture.VerifyRedirectsBackToConfirmDetailsAndSendRequestPage(result as RedirectToRouteResult);
         }
     }
 
@@ -60,7 +61,8 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Controllers.ApprenticeCont
                Mock.Of<ICookieStorageService<IndexRequest>>(),
                Mock.Of<ICommitmentsApiClient>(),
                Mock.Of<ILinkGenerator>(),
-               Mock.Of<ILogger<ApprenticeController>>());
+               Mock.Of<ILogger<ApprenticeController>>(),
+               Mock.Of<IAuthorizationService>());
         }
 
         public IActionResult WhatIsTheNewStartDate(WhatIsTheNewStartDateViewModel viewModel)
@@ -68,11 +70,11 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Controllers.ApprenticeCont
             return _controller.WhatIsTheNewStartDate(viewModel);
         }
 
-        public void VerifyRedirectsToTheWhatIsTheNewStopDatePage(IActionResult result)
+        public void VerifyRedirectsToTheWhatIsTheNewEndDatePage(IActionResult result)
         {
             var redirectResult = (RedirectToRouteResult)result;
 
-            Assert.AreEqual(RouteNames.WhatIsTheNewStopDate, redirectResult.RouteName);
+            Assert.AreEqual(RouteNames.WhatIsTheNewEndDate, redirectResult.RouteName);
         }
 
         public void VerifyRedirectsBackToConfirmDetailsAndSendRequestPage(IActionResult result)

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Controllers/ApprenticeControllerTests/WhenRequestingTheWhatIsTheNewStartDatePage.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Controllers/ApprenticeControllerTests/WhenRequestingTheWhatIsTheNewStartDatePage.cs
@@ -1,6 +1,4 @@
-﻿
-
-using AutoFixture;
+﻿using AutoFixture;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Controllers/ApprenticeControllerTests/WhenRequestingTheWhatIsTheNewStartDatePage.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Controllers/ApprenticeControllerTests/WhenRequestingTheWhatIsTheNewStartDatePage.cs
@@ -1,4 +1,6 @@
-﻿using AutoFixture;
+﻿
+
+using AutoFixture;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -12,43 +14,43 @@ using System.Threading.Tasks;
 
 namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Controllers.ApprenticeControllerTests
 {
-    public class WhenCallingGetWhoWillEnterTheDetailsTests
+    public class WhenRequestingTheWhatIsTheNewStartDatePage 
     {
-        WhenCallingGetWhoWillEnterTheDetailsTestsFixture _fixture;
+        private WhenRequestingTheWhatIsTheNewStartDatePageTestFixture _fixture;
 
         [SetUp]
         public void Arrange()
         {
-            _fixture = new WhenCallingGetWhoWillEnterTheDetailsTestsFixture();
+            _fixture = new WhenRequestingTheWhatIsTheNewStartDatePageTestFixture();
         }
 
         [Test]
         public async Task ThenTheCorrectViewIsReturned()
         {
-            var result = await _fixture.WhoWillEnterTheDetails();
+            var result = await _fixture.WhatIsTheNewStartDate();
 
             _fixture.VerifyViewModel(result as ViewResult);
         }
     }
 
-    public class WhenCallingGetWhoWillEnterTheDetailsTestsFixture
+    public class WhenRequestingTheWhatIsTheNewStartDatePageTestFixture
     {
-        private readonly WhoWillEnterTheDetailsRequest _request;
-        private readonly WhoWillEnterTheDetailsViewModel _viewModel;
+        private readonly WhatIsTheNewStartDateRequest _request;
+        private readonly WhatIsTheNewStartDateViewModel _viewModel;
 
         private readonly Mock<IModelMapper> _mockMapper;
 
         private readonly ApprenticeController _controller;
 
-        public WhenCallingGetWhoWillEnterTheDetailsTestsFixture()
+        public WhenRequestingTheWhatIsTheNewStartDatePageTestFixture()
         {
             var autoFixture = new Fixture();
 
-            _request = autoFixture.Create<WhoWillEnterTheDetailsRequest>();
-            _viewModel = autoFixture.Create<WhoWillEnterTheDetailsViewModel>();
+            _request = autoFixture.Create<WhatIsTheNewStartDateRequest>();
+            _viewModel = autoFixture.Create<WhatIsTheNewStartDateViewModel>();
 
             _mockMapper = new Mock<IModelMapper>();
-            _mockMapper.Setup(m => m.Map<WhoWillEnterTheDetailsViewModel>(_request))
+            _mockMapper.Setup(m => m.Map<WhatIsTheNewStartDateViewModel>(_request))
                 .ReturnsAsync(_viewModel);
 
             _controller = new ApprenticeController(_mockMapper.Object,
@@ -58,16 +60,16 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Controllers.ApprenticeCont
                 Mock.Of<ILogger<ApprenticeController>>());
         }
 
-        public async Task<IActionResult> WhoWillEnterTheDetails()
+        public async Task<IActionResult> WhatIsTheNewStartDate()
         {
-            return await _controller.WhoWillEnterTheDetails(_request);
+            return await _controller.WhatIsTheNewStartDate(_request);
         }
 
         public void VerifyViewModel(ViewResult viewResult)
         {
-            var viewModel = viewResult.Model as WhoWillEnterTheDetailsViewModel;
+            var viewModel = viewResult.Model as WhatIsTheNewStartDateViewModel;
 
-            Assert.IsInstanceOf<WhoWillEnterTheDetailsViewModel>(viewModel);
+            Assert.IsInstanceOf<WhatIsTheNewStartDateViewModel>(viewModel);
             Assert.AreEqual(_viewModel, viewModel);
         }
     }

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Controllers/ApprenticeControllerTests/WhenRequestingTheWhatIsTheNewStartDatePage.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Controllers/ApprenticeControllerTests/WhenRequestingTheWhatIsTheNewStartDatePage.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
+using SFA.DAS.Authorization.Services;
 using SFA.DAS.CommitmentsV2.Api.Client;
 using SFA.DAS.CommitmentsV2.Shared.Interfaces;
 using SFA.DAS.EmployerCommitmentsV2.Web.Controllers;
@@ -35,7 +36,7 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Controllers.ApprenticeCont
 
     public class WhenRequestingTheWhatIsTheNewStartDatePageTestFixture
     {
-        private readonly WhatIsTheNewStartDateRequest _request;
+        private readonly EmployerLedChangeOfProviderRequest _request;
         private readonly WhatIsTheNewStartDateViewModel _viewModel;
 
         private readonly Mock<IModelMapper> _mockMapper;
@@ -46,7 +47,7 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Controllers.ApprenticeCont
         {
             var autoFixture = new Fixture();
 
-            _request = autoFixture.Create<WhatIsTheNewStartDateRequest>();
+            _request = autoFixture.Create<EmployerLedChangeOfProviderRequest>();
             _viewModel = autoFixture.Create<WhatIsTheNewStartDateViewModel>();
 
             _mockMapper = new Mock<IModelMapper>();
@@ -57,7 +58,8 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Controllers.ApprenticeCont
                 Mock.Of<ICookieStorageService<IndexRequest>>(),
                 Mock.Of<ICommitmentsApiClient>(),
                 Mock.Of<ILinkGenerator>(),
-                Mock.Of<ILogger<ApprenticeController>>());
+                Mock.Of<ILogger<ApprenticeController>>(),
+                Mock.Of<IAuthorizationService>());
         }
 
         public async Task<IActionResult> WhatIsTheNewStartDate()

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Extensions/MonthYearModelExtensionsTests.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Extensions/MonthYearModelExtensionsTests.cs
@@ -16,19 +16,39 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Extensions
             _monthYear = new MonthYearModel("") { Month = 3, Year = 2020 };
         }
 
-        //Expand to separate tests to explain cases better
-        [TestCase(2019, 1, 1, true)]
-        [TestCase(2020, 1, 1, true)] 
-        [TestCase(2020, 3, 1, true)]
-        [TestCase(2020, 3, 31, true )]
-        [TestCase(2020, 5, 1, false)]
-        public void IsGreaterThanOrEqualToDateTimeMonthYear(int year, int month, int day, bool expectedResult)
+        [TestCase(2019, 1, 1)]
+        [TestCase(2020, 1, 1)]
+        public void WhenDateTimeIsBeforeMonthYearModel_IsEqualToOrAfterMonthYearOfDateTime_ReturnsTrue(int year, int month, int day)
         {
-            var date = new DateTime(year, month, day);
+            var dateTime = new DateTime(year, month, day);
 
-            var actualResult = _monthYear.IsGreaterThanOrEqualToDateTimeMonthYear(date);
+            var actualResult = _monthYear.IsEqualToOrAfterMonthYearOfDateTime(dateTime);
 
-            Assert.AreEqual(expectedResult, actualResult);
+            Assert.AreEqual(true, actualResult);
+        }
+
+        [TestCase(2020, 3, 1)]
+        [TestCase(2020, 3, 31)]
+        [TestCase(2020, 3, 31, 23, 59, 59)]
+        public void WhenDateTimeIsAnywhereWithinMonthYearModel_IsEqualToOrAfterMonthYearOfDateTime_ReturnsTrue(int year, int month, int day, int hour = 0, int min = 0, int sec = 0)
+        {
+            var dateTime = new DateTime(year, month, day, hour, min, sec);
+
+            var actualResult = _monthYear.IsEqualToOrAfterMonthYearOfDateTime(dateTime);
+
+            Assert.AreEqual(true, actualResult);
+        }
+
+        [TestCase(2020, 4, 1)]
+        [TestCase(2020, 4, 30)]
+        [TestCase(2021, 3, 31)]
+        public void WhenDateTimeIsAfterMonthYearModel_IsEqualToOrAfterMonthYearOfDateTime_ReturnsFalse(int year, int month, int day)
+        {
+            var dateTime = new DateTime(year, month, day);
+
+            var actualResult = _monthYear.IsEqualToOrAfterMonthYearOfDateTime(dateTime);
+
+            Assert.AreEqual(false, actualResult);
         }
     }
 }

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Extensions/MonthYearModelExtensionsTests.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Extensions/MonthYearModelExtensionsTests.cs
@@ -1,0 +1,34 @@
+﻿using NUnit.Framework;
+using SFA.DAS.CommitmentsV2.Shared.Models;
+using SFA.DAS.EmployerCommitmentsV2.Web.Extensions;
+using System;
+
+namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Extensions
+{
+    [TestFixture]
+    public class MonthYearModelExtensionsTests
+    {
+        private MonthYearModel _monthYear;
+
+        [SetUp]
+        public void Arrange()
+        {
+            _monthYear = new MonthYearModel("") { Month = 3, Year = 2020 };
+        }
+
+        //Expand to separate tests to explain cases better
+        [TestCase(2019, 1, 1, true)]
+        [TestCase(2020, 1, 1, true)] 
+        [TestCase(2020, 3, 1, true)]
+        [TestCase(2020, 3, 31, true )]
+        [TestCase(2020, 5, 1, false)]
+        public void IsGreaterThanOrEqualToDateTimeMonthYear(int year, int month, int day, bool expectedResult)
+        {
+            var date = new DateTime(year, month, day);
+
+            var actualResult = _monthYear.IsGreaterThanOrEqualToDateTimeMonthYear(date);
+
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Mappers/Apprentice/WhatIsTheNewStartDateViewModelMapperTests.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Mappers/Apprentice/WhatIsTheNewStartDateViewModelMapperTests.cs
@@ -5,10 +5,6 @@ using SFA.DAS.CommitmentsV2.Api.Client;
 using SFA.DAS.CommitmentsV2.Api.Types.Responses;
 using SFA.DAS.EmployerCommitmentsV2.Web.Mappers.Apprentice;
 using SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice;
-using SFA.DAS.Testing.AutoFixture;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -18,6 +14,7 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Mappers.Apprentice
     {
         private Mock<ICommitmentsApiClient> _mockCommitmentsApiClient;
 
+        private EmployerLedChangeOfProviderRequest _request;
         private GetApprenticeshipResponse _apprenticeshipResponse;
 
         private WhatIsTheNewStartDateViewModelMapper _mapper;
@@ -27,7 +24,8 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Mappers.Apprentice
         {
             var _autoFixture = new Fixture();
 
-            _apprenticeshipResponse = _autoFixture.Build<GetApprenticeshipResponse>().Create();
+            _request = _autoFixture.Create<EmployerLedChangeOfProviderRequest>();
+            _apprenticeshipResponse = _autoFixture.Create<GetApprenticeshipResponse>();
 
             _mockCommitmentsApiClient = new Mock<ICommitmentsApiClient>();
             _mockCommitmentsApiClient.Setup(m => m.GetApprenticeship(It.IsAny<long>(), It.IsAny<CancellationToken>()))
@@ -36,52 +34,63 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Mappers.Apprentice
             _mapper = new WhatIsTheNewStartDateViewModelMapper(_mockCommitmentsApiClient.Object);
         }
 
-        [Test, MoqAutoData]
-        public async Task ApprenticeshipHashedId_IsMapped(WhatIsTheNewStartDateRequest request)
+        [Test]
+        public async Task ApprenticeshipHashedId_IsMapped()
         {
-            var result = await _mapper.Map(request);
+            var result = await _mapper.Map(_request);
 
-            Assert.AreEqual(request.ApprenticeshipHashedId, result.ApprenticeshipHashedId);
+            Assert.AreEqual(_request.ApprenticeshipHashedId, result.ApprenticeshipHashedId);
         }
 
-        [Test, MoqAutoData]
-        public async Task AccountHashedId_IsMapped(WhatIsTheNewStartDateRequest request)
+        [Test]
+        public async Task AccountHashedId_IsMapped()
         {
-            var result = await _mapper.Map(request);
+            var result = await _mapper.Map(_request);
 
-            Assert.AreEqual(request.AccountHashedId, result.AccountHashedId);
+            Assert.AreEqual(_request.AccountHashedId, result.AccountHashedId);
         }
 
-        [Test, MoqAutoData]
-        public async Task ProviderId_IsMapped(WhatIsTheNewStartDateRequest request)
+        [Test]
+        public async Task ProviderId_IsMapped()
         {
-            var result = await _mapper.Map(request);
+            var result = await _mapper.Map(_request);
 
-            Assert.AreEqual(request.ProviderId, result.ProviderId);
+            Assert.AreEqual(_request.ProviderId, result.ProviderId);
         }
 
-        [Test, MoqAutoData]
-        public async Task WhenRequestingTheWhatIsTheNewStartDatePage_ThenTheGetApprenticeshipIsCalled(WhatIsTheNewStartDateRequest request)
+        [Test]
+        public async Task WhenRequestingTheWhatIsTheNewStartDatePage_ThenTheGetApprenticeshipIsCalled()
         {
-            var result = await _mapper.Map(request);
+            var result = await _mapper.Map(_request);
 
-            _mockCommitmentsApiClient.Verify(m => m.GetApprenticeship(request.ApprenticeshipId, It.IsAny<CancellationToken>()), Times.Once());
+            _mockCommitmentsApiClient.Verify(m => m.GetApprenticeship(_request.ApprenticeshipId, It.IsAny<CancellationToken>()), Times.Once());
         }
 
-        [Test, MoqAutoData]
-        public async Task StopDate_IsMapped(WhatIsTheNewStartDateRequest request)
+        [Test]
+        public async Task StopDate_IsMapped()
         {
-            var result = await _mapper.Map(request);
+            var result = await _mapper.Map(_request);
 
             Assert.AreEqual(_apprenticeshipResponse.StopDate, result.StopDate);
         }
 
-        [Test, MoqAutoData]
-        public async Task ProviderName_IsMapped(WhatIsTheNewStartDateRequest request)
+        [Test]
+        public async Task ProviderName_IsMapped()
         {
-            var result = await _mapper.Map(request);
+            var result = await _mapper.Map(_request);
 
             Assert.AreEqual(_apprenticeshipResponse.ProviderName, result.ProviderName);
+        }
+
+        [TestCase(true, true)]
+        [TestCase(null, false)]
+        public async Task EditFlag_IsMapped(bool? edit, bool expectedResult)
+        {
+            _request.Edit = edit;
+
+            var result = await _mapper.Map(_request);
+
+            Assert.AreEqual(expectedResult, result.Edit);
         }
     }
 }

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Mappers/Apprentice/WhatIsTheNewStartDateViewModelMapperTests.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Mappers/Apprentice/WhatIsTheNewStartDateViewModelMapperTests.cs
@@ -1,0 +1,87 @@
+﻿using AutoFixture;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.CommitmentsV2.Api.Client;
+using SFA.DAS.CommitmentsV2.Api.Types.Responses;
+using SFA.DAS.EmployerCommitmentsV2.Web.Mappers.Apprentice;
+using SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice;
+using SFA.DAS.Testing.AutoFixture;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Mappers.Apprentice
+{
+    public class WhatIsTheNewStartDateViewModelMapperTests
+    {
+        private Mock<ICommitmentsApiClient> _mockCommitmentsApiClient;
+
+        private GetApprenticeshipResponse _apprenticeshipResponse;
+
+        private WhatIsTheNewStartDateViewModelMapper _mapper;
+
+        [SetUp]
+        public void Arrange()
+        {
+            var _autoFixture = new Fixture();
+
+            _apprenticeshipResponse = _autoFixture.Build<GetApprenticeshipResponse>().Create();
+
+            _mockCommitmentsApiClient = new Mock<ICommitmentsApiClient>();
+            _mockCommitmentsApiClient.Setup(m => m.GetApprenticeship(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_apprenticeshipResponse);
+
+            _mapper = new WhatIsTheNewStartDateViewModelMapper(_mockCommitmentsApiClient.Object);
+        }
+
+        [Test, MoqAutoData]
+        public async Task ApprenticeshipHashedId_IsMapped(WhatIsTheNewStartDateRequest request)
+        {
+            var result = await _mapper.Map(request);
+
+            Assert.AreEqual(request.ApprenticeshipHashedId, result.ApprenticeshipHashedId);
+        }
+
+        [Test, MoqAutoData]
+        public async Task AccountHashedId_IsMapped(WhatIsTheNewStartDateRequest request)
+        {
+            var result = await _mapper.Map(request);
+
+            Assert.AreEqual(request.AccountHashedId, result.AccountHashedId);
+        }
+
+        [Test, MoqAutoData]
+        public async Task ProviderId_IsMapped(WhatIsTheNewStartDateRequest request)
+        {
+            var result = await _mapper.Map(request);
+
+            Assert.AreEqual(request.ProviderId, result.ProviderId);
+        }
+
+        [Test, MoqAutoData]
+        public async Task WhenRequestingTheWhatIsTheNewStartDatePage_ThenTheGetApprenticeshipIsCalled(WhatIsTheNewStartDateRequest request)
+        {
+            var result = await _mapper.Map(request);
+
+            _mockCommitmentsApiClient.Verify(m => m.GetApprenticeship(request.ApprenticeshipId, It.IsAny<CancellationToken>()), Times.Once());
+        }
+
+        [Test, MoqAutoData]
+        public async Task StopDate_IsMapped(WhatIsTheNewStartDateRequest request)
+        {
+            var result = await _mapper.Map(request);
+
+            Assert.AreEqual(_apprenticeshipResponse.StopDate, result.StopDate);
+        }
+
+        [Test, MoqAutoData]
+        public async Task ProviderName_IsMapped(WhatIsTheNewStartDateRequest request)
+        {
+            var result = await _mapper.Map(request);
+
+            Assert.AreEqual(_apprenticeshipResponse.ProviderName, result.ProviderName);
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Mappers/Apprentice/WhatIsTheNewStartDateViewModelMapperTests.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Mappers/Apprentice/WhatIsTheNewStartDateViewModelMapperTests.cs
@@ -59,6 +59,14 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Mappers.Apprentice
         }
 
         [Test]
+        public async Task ProviderName_IsMapped()
+        {
+            var result = await _mapper.Map(_request);
+
+            Assert.AreEqual(_request.ProviderName, result.ProviderName);
+        }
+
+        [Test]
         public async Task WhenRequestingTheWhatIsTheNewStartDatePage_ThenTheGetApprenticeshipIsCalled()
         {
             var result = await _mapper.Map(_request);
@@ -72,14 +80,6 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Mappers.Apprentice
             var result = await _mapper.Map(_request);
 
             Assert.AreEqual(_apprenticeshipResponse.StopDate, result.StopDate);
-        }
-
-        [Test]
-        public async Task ProviderName_IsMapped()
-        {
-            var result = await _mapper.Map(_request);
-
-            Assert.AreEqual(_apprenticeshipResponse.ProviderName, result.ProviderName);
         }
 
         [TestCase(true, true)]

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Validators/EmployerLedChangeOfProviderRequestValidatorTests.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Validators/EmployerLedChangeOfProviderRequestValidatorTests.cs
@@ -1,0 +1,54 @@
+﻿using FluentValidation.TestHelper;
+using NUnit.Framework;
+using SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice;
+using SFA.DAS.EmployerCommitmentsV2.Web.Validators;
+using System;
+using System.Linq.Expressions;
+
+namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Validators
+{
+    public class EmployerLedChangeOfProviderRequestValidatorTests
+    {
+        [TestCase("5143541", true)]
+        [TestCase(" ", false)]
+        [TestCase("", false)]
+        [TestCase(null, false)]
+        public void ThenAccountHashedIdIsValidated(string accountHashedId, bool expectedValid)
+        {
+            var request = new EmployerLedChangeOfProviderRequest() { AccountHashedId = accountHashedId };
+            AssertValidationResult(x => x.AccountHashedId, request, expectedValid);
+        }
+        [TestCase("", false)]
+        [TestCase("31", true)]
+        [TestCase(" ", false)]
+        [TestCase(null, false)]
+        public void ThenApprenticeshipHashedIdIsValidated(string apprenticeshipHashedId, bool expectedValid)
+        {
+            var request = new EmployerLedChangeOfProviderRequest() { ApprenticeshipHashedId = apprenticeshipHashedId };
+            AssertValidationResult(x => x.ApprenticeshipHashedId, request, expectedValid);
+        }
+
+        [TestCase(default(long), false)]
+        [TestCase(-2342, false)]
+        [TestCase(234, true)]
+        public void ThenProviderIsValidated(long providerId, bool expectedValid)
+        {
+            var request = new EmployerLedChangeOfProviderRequest() { ProviderId = providerId };
+            AssertValidationResult(x => x.ProviderId, request, expectedValid);
+        }
+
+        private void AssertValidationResult<T>(Expression<Func<EmployerLedChangeOfProviderRequest, T>> property, EmployerLedChangeOfProviderRequest instance, bool expectedValid)
+        {
+            var validator = new EmployerLedChangeOfProviderRequestValidator();
+
+            if (expectedValid)
+            {
+                validator.ShouldNotHaveValidationErrorFor(property, instance);
+            }
+            else
+            {
+                validator.ShouldHaveValidationErrorFor(property, instance);
+            }
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Validators/WhatIsTheNewStartDateViewModelValidatorTests.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Validators/WhatIsTheNewStartDateViewModelValidatorTests.cs
@@ -1,0 +1,38 @@
+﻿using FluentValidation.TestHelper;
+using NUnit.Framework;
+using SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice;
+using SFA.DAS.EmployerCommitmentsV2.Web.Validators;
+using System;
+using System.Linq.Expressions;
+
+namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Validators
+{
+    public class WhatIsTheNewStartDateViewModelValidatorTests
+    {
+        [TestCase(12, 2000, true)]
+        [TestCase(13, 2000, false)]
+        [TestCase(null, 2000, false)]
+        [TestCase(1, null, false)]
+        [TestCase(null, null, false)]
+        public void Validate(int? month, int? year, bool expectedValid)
+        {
+            var model = new WhatIsTheNewStartDateViewModel { NewStartMonth = month, NewStartYear = year };
+
+            AssertValidationResult(x => x.NewStartDate, model, expectedValid);
+        }
+
+        private void AssertValidationResult<T>(Expression<Func<WhatIsTheNewStartDateViewModel, T>> property, WhatIsTheNewStartDateViewModel instance, bool expectedValid)
+        {
+            var validator = new WhatIsTheNewStartDateViewModelValidator();
+
+            if (expectedValid)
+            {
+                validator.ShouldNotHaveValidationErrorFor(property, instance);
+            }
+            else
+            {
+                validator.ShouldHaveValidationErrorFor(property, instance);
+            }
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Validators/WhatIsTheNewStartDateViewModelValidatorTests.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web.UnitTests/Validators/WhatIsTheNewStartDateViewModelValidatorTests.cs
@@ -9,16 +9,25 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.UnitTests.Validators
 {
     public class WhatIsTheNewStartDateViewModelValidatorTests
     {
+        private DateTime _stopDate = new DateTime(2020, 12, 10);
+
+        // this could be broken down to test each scenario and excepted outcome
         [TestCase(12, 2000, true)]
         [TestCase(13, 2000, false)]
         [TestCase(null, 2000, false)]
         [TestCase(1, null, false)]
         [TestCase(null, null, false)]
-        public void Validate(int? month, int? year, bool expectedValid)
+        public void ValidateRealDate(int? month, int? year, bool expectedValid)
         {
             var model = new WhatIsTheNewStartDateViewModel { NewStartMonth = month, NewStartYear = year };
 
             AssertValidationResult(x => x.NewStartDate, model, expectedValid);
+        }
+
+        [TestCase(12, 2020, true)]
+        public void ValidateNewStartDateIsOnOrAfterStopDate(int? month, int? year, bool expectedValid)
+        {
+
         }
 
         private void AssertValidationResult<T>(Expression<Func<WhatIsTheNewStartDateViewModel, T>> property, WhatIsTheNewStartDateViewModel instance, bool expectedValid)

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Controllers/ApprenticeController.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Controllers/ApprenticeController.cs
@@ -179,7 +179,7 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.Controllers
         {
             if (viewModel.EmployerWillAdd == true)
             {
-                return RedirectToRoute(RouteNames.WhatIsTheNewStartDate, new { viewModel.AccountHashedId, viewModel.ApprenticeshipHashedId, viewModel.ProviderId });
+                return RedirectToRoute(RouteNames.WhatIsTheNewStartDate, new { viewModel.AccountHashedId, viewModel.ApprenticeshipHashedId, viewModel.ProviderId, viewModel.ProviderName });
             }
             else
             {
@@ -204,10 +204,10 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.Controllers
         {
             if (vm.Edit)
             {
-                return RedirectToRoute(RouteNames.ConfirmDetailsAndSendRequest, new { vm.AccountHashedId, vm.ApprenticeshipHashedId, vm.ProviderId, vm.NewStartMonth, vm.NewStartYear, vm.NewEndMonth, vm.NewEndYear, vm.NewPrice });
+                return RedirectToRoute(RouteNames.ConfirmDetailsAndSendRequest, new { vm.ProviderName, vm.AccountHashedId, vm.ApprenticeshipHashedId, vm.ProviderId, vm.NewStartMonth, vm.NewStartYear, vm.NewEndMonth, vm.NewEndYear, vm.NewPrice });
             }
 
-            return RedirectToRoute(RouteNames.WhatIsTheNewEndDate, new { vm.AccountHashedId, vm.ApprenticeshipHashedId, vm.ProviderId, vm.NewStartMonth, vm.NewStartYear});
+            return RedirectToRoute(RouteNames.WhatIsTheNewEndDate, new { vm.ProviderName, vm.AccountHashedId, vm.ApprenticeshipHashedId, vm.ProviderId, vm.NewStartMonth, vm.NewStartYear});
         }
 
         [HttpGet]

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Controllers/ApprenticeController.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Controllers/ApprenticeController.cs
@@ -190,7 +190,7 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.Controllers
         [HttpGet]
         [Route("{apprenticeshipHashedId}/change-provider/start-date", Name = RouteNames.WhatIsTheNewStartDate)]
         [DasAuthorize(EmployerFeature.ChangeOfProvider)]
-        public async Task<IActionResult> WhatIsTheNewStartDate(WhatIsTheNewStartDateRequest request)
+        public async Task<IActionResult> WhatIsTheNewStartDate(EmployerLedChangeOfProviderRequest request)
         {
             var viewModel = await _modelMapper.Map<WhatIsTheNewStartDateViewModel>(request);
 
@@ -200,8 +200,31 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.Controllers
         [HttpPost]
         [Route("{apprenticeshipHashedId}/change-provider/start-date", Name = RouteNames.WhatIsTheNewStartDate)]
         [DasAuthorize(EmployerFeature.ChangeOfProvider)]
-        public IActionResult WhatIsTheNewStartDate(WhatIsTheNewStartDateViewModel viewModel)
+        public IActionResult WhatIsTheNewStartDate(WhatIsTheNewStartDateViewModel vm)
         {
+            if (vm.Edit)
+            {
+                return RedirectToRoute(RouteNames.ConfirmDetailsAndSendRequest, new { vm.AccountHashedId, vm.ApprenticeshipHashedId, vm.ProviderId, vm.NewStartMonth, vm.NewStartYear, vm.NewEndMonth, vm.NewEndYear, vm.NewPrice });
+            }
+
+            return RedirectToRoute(RouteNames.WhatIsTheNewEndDate, new { vm.AccountHashedId, vm.ApprenticeshipHashedId, vm.ProviderId, vm.NewStartMonth, vm.NewStartYear});
+        }
+
+        [HttpGet]
+        [Route("{apprenticeshipHashedId}/change-provider/end-date", Name = RouteNames.WhatIsTheNewEndDate)]
+        [DasAuthorize(EmployerFeature.ChangeOfProvider)]
+        public IActionResult WhatIsTheNewEndDate(EmployerLedChangeOfProviderRequest request)
+        {
+            return View();
+        }
+
+        [HttpGet]
+        [Route("{apprenticeshipHashedId}/change-provider/confirm-details-and-send-request", Name = RouteNames.ConfirmDetailsAndSendRequest)]
+        [DasAuthorize(EmployerFeature.ChangeOfProvider)]
+        public async Task<IActionResult> ConfirmDetailsAndSendRequestPage(EmployerLedChangeOfProviderRequest request)
+        {
+            var viewModel = await _modelMapper.Map<ConfirmDetailsAndSendViewModel>(request); 
+
             return View(viewModel);
         }
 

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Controllers/ApprenticeController.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Controllers/ApprenticeController.cs
@@ -181,13 +181,22 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.Controllers
             }
         }
 
-        // Placeholder for CON-2519
         [HttpGet]
         [Route("{apprenticeshipHashedId}/change-provider/start-date", Name = RouteNames.WhatIsTheNewStartDate)]
         [DasAuthorize(EmployerFeature.ChangeOfProvider)]
-        public IActionResult WhatIsTheNewStartDate()
+        public async Task<IActionResult> WhatIsTheNewStartDate(WhatIsTheNewStartDateRequest request)
         {
-            return View();
+            var viewModel = await _modelMapper.Map<WhatIsTheNewStartDateViewModel>(request);
+
+            return View(viewModel);
+        }
+
+        [HttpPost]
+        [Route("{apprenticeshipHashedId}/change-provider/start-date", Name = RouteNames.WhatIsTheNewStartDate)]
+        [DasAuthorize(EmployerFeature.ChangeOfProvider)]
+        public IActionResult WhatIsTheNewStartDate(WhatIsTheNewStartDateViewModel viewModel)
+        {
+            return View(viewModel);
         }
 
         [Route("{apprenticeshipHashedId}/change-provider/send-request", Name = RouteNames.SendRequestNewTrainingProvider)]

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Extensions/MonthYearModelExtension.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Extensions/MonthYearModelExtension.cs
@@ -5,7 +5,7 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.Extensions
 {
     public static class MonthYearModelExtension
     {
-        public static bool IsGreaterThanOrEqualToDateTimeMonthYear(this MonthYearModel monthYearModel, DateTime dateTime)
+        public static bool IsEqualToOrAfterMonthYearOfDateTime(this MonthYearModel monthYearModel, DateTime dateTime)
         {
             var result = DateTime.Compare(new DateTime(monthYearModel.Year.Value, monthYearModel.Month.Value, 1), new DateTime(dateTime.Year, dateTime.Month, 1));
 

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Extensions/MonthYearModelExtension.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Extensions/MonthYearModelExtension.cs
@@ -1,0 +1,15 @@
+﻿using SFA.DAS.CommitmentsV2.Shared.Models;
+using System;
+
+namespace SFA.DAS.EmployerCommitmentsV2.Web.Extensions
+{
+    public static class MonthYearModelExtension
+    {
+        public static bool IsGreaterThanOrEqualToDateTimeMonthYear(this MonthYearModel monthYearModel, DateTime dateTime)
+        {
+            var result = DateTime.Compare(new DateTime(monthYearModel.Year.Value, monthYearModel.Month.Value, 1), new DateTime(dateTime.Year, dateTime.Month, 1));
+
+            return (result >= 0);
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Extensions/MonthYearModelExtension.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Extensions/MonthYearModelExtension.cs
@@ -7,7 +7,7 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.Extensions
     {
         public static bool IsEqualToOrAfterMonthYearOfDateTime(this MonthYearModel monthYearModel, DateTime dateTime)
         {
-            var result = DateTime.Compare(new DateTime(monthYearModel.Year.Value, monthYearModel.Month.Value, 1), new DateTime(dateTime.Year, dateTime.Month, 1));
+            var result = DateTime.Compare(monthYearModel.Date.Value, new DateTime(dateTime.Year, dateTime.Month, 1));
 
             return (result >= 0);
         }

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Extensions/MonthYearModelExtension.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Extensions/MonthYearModelExtension.cs
@@ -7,9 +7,7 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.Extensions
     {
         public static bool IsEqualToOrAfterMonthYearOfDateTime(this MonthYearModel monthYearModel, DateTime dateTime)
         {
-            var result = DateTime.Compare(monthYearModel.Date.Value, new DateTime(dateTime.Year, dateTime.Month, 1));
-
-            return (result >= 0);
+            return monthYearModel.Date.Value >= new DateTime(dateTime.Year, dateTime.Month, 1);
         }
     }
 }

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Mappers/Apprentice/ConfirmDetailsAndSendViewModelMapper.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Mappers/Apprentice/ConfirmDetailsAndSendViewModelMapper.cs
@@ -1,0 +1,27 @@
+﻿
+
+using SFA.DAS.CommitmentsV2.Shared.Interfaces;
+using SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.EmployerCommitmentsV2.Web.Mappers.Apprentice
+{
+    public class ConfirmDetailsAndSendViewModelMapper : IMapper<EmployerLedChangeOfProviderRequest, ConfirmDetailsAndSendViewModel>
+    {
+        public Task<ConfirmDetailsAndSendViewModel> Map(EmployerLedChangeOfProviderRequest source)
+        {
+            var result = new ConfirmDetailsAndSendViewModel
+            {
+                AccountHashedId = source.AccountHashedId,
+                ApprenticeshipHashedId = source.ApprenticeshipHashedId,
+                NewStartMonth = source.NewStartMonth,
+                NewStartYear = source.NewStartYear,
+                NewEndMonth = source.NewEndMonth,
+                NewEndYear = source.NewEndYear,
+                NewPrice = source.NewPrice
+            };
+
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Mappers/Apprentice/ConfirmDetailsAndSendViewModelMapper.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Mappers/Apprentice/ConfirmDetailsAndSendViewModelMapper.cs
@@ -1,6 +1,4 @@
-﻿
-
-using SFA.DAS.CommitmentsV2.Shared.Interfaces;
+﻿using SFA.DAS.CommitmentsV2.Shared.Interfaces;
 using SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice;
 using System.Threading.Tasks;
 
@@ -14,6 +12,9 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.Mappers.Apprentice
             {
                 AccountHashedId = source.AccountHashedId,
                 ApprenticeshipHashedId = source.ApprenticeshipHashedId,
+                ProviderId = source.ProviderId,
+                ProviderName = source.ProviderName,
+                EmployerWillAdd = source.EmployerWillAdd,
                 NewStartMonth = source.NewStartMonth,
                 NewStartYear = source.NewStartYear,
                 NewEndMonth = source.NewEndMonth,

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Mappers/Apprentice/WhatIsTheNewStartDateViewModelMapper.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Mappers/Apprentice/WhatIsTheNewStartDateViewModelMapper.cs
@@ -23,7 +23,7 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.Mappers.Apprentice
             {
                 AccountHashedId = source.AccountHashedId,
                 ApprenticeshipHashedId = source.ApprenticeshipHashedId,
-                ProviderName = apprenticeship.ProviderName,
+                ProviderName = source.ProviderName,
                 ProviderId = source.ProviderId,
                 StopDate = apprenticeship.StopDate.Value,
                 Edit = source.Edit ?? false

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Mappers/Apprentice/WhatIsTheNewStartDateViewModelMapper.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Mappers/Apprentice/WhatIsTheNewStartDateViewModelMapper.cs
@@ -1,0 +1,32 @@
+﻿using SFA.DAS.CommitmentsV2.Api.Client;
+using SFA.DAS.CommitmentsV2.Shared.Interfaces;
+using SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.EmployerCommitmentsV2.Web.Mappers.Apprentice
+{
+    public class WhatIsTheNewStartDateViewModelMapper : IMapper<WhatIsTheNewStartDateRequest, WhatIsTheNewStartDateViewModel>
+    {
+
+        private readonly ICommitmentsApiClient _client;
+
+        public WhatIsTheNewStartDateViewModelMapper(ICommitmentsApiClient client)
+        {
+            _client = client;
+        }
+
+        public async Task<WhatIsTheNewStartDateViewModel> Map(WhatIsTheNewStartDateRequest source)
+        {
+            var apprenticeship = await _client.GetApprenticeship(source.ApprenticeshipId);
+            
+            return new WhatIsTheNewStartDateViewModel
+            {
+                AccountHashedId = source.AccountHashedId,
+                ApprenticeshipHashedId = source.ApprenticeshipHashedId,
+                ProviderName = apprenticeship.ProviderName,
+                ProviderId = source.ProviderId,
+                StopDate = apprenticeship.StopDate.Value
+            };
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Mappers/Apprentice/WhatIsTheNewStartDateViewModelMapper.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Mappers/Apprentice/WhatIsTheNewStartDateViewModelMapper.cs
@@ -25,6 +25,7 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.Mappers.Apprentice
                 ApprenticeshipHashedId = source.ApprenticeshipHashedId,
                 ProviderName = source.ProviderName,
                 ProviderId = source.ProviderId,
+                EmployerWillAdd = source.EmployerWillAdd,
                 StopDate = apprenticeship.StopDate.Value,
                 Edit = source.Edit ?? false
             };

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Mappers/Apprentice/WhatIsTheNewStartDateViewModelMapper.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Mappers/Apprentice/WhatIsTheNewStartDateViewModelMapper.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace SFA.DAS.EmployerCommitmentsV2.Web.Mappers.Apprentice
 {
-    public class WhatIsTheNewStartDateViewModelMapper : IMapper<WhatIsTheNewStartDateRequest, WhatIsTheNewStartDateViewModel>
+    public class WhatIsTheNewStartDateViewModelMapper : IMapper<EmployerLedChangeOfProviderRequest, WhatIsTheNewStartDateViewModel>
     {
 
         private readonly ICommitmentsApiClient _client;
@@ -15,7 +15,7 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.Mappers.Apprentice
             _client = client;
         }
 
-        public async Task<WhatIsTheNewStartDateViewModel> Map(WhatIsTheNewStartDateRequest source)
+        public async Task<WhatIsTheNewStartDateViewModel> Map(EmployerLedChangeOfProviderRequest source)
         {
             var apprenticeship = await _client.GetApprenticeship(source.ApprenticeshipId);
             
@@ -25,7 +25,8 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.Mappers.Apprentice
                 ApprenticeshipHashedId = source.ApprenticeshipHashedId,
                 ProviderName = apprenticeship.ProviderName,
                 ProviderId = source.ProviderId,
-                StopDate = apprenticeship.StopDate.Value
+                StopDate = apprenticeship.StopDate.Value,
+                Edit = source.Edit ?? false
             };
         }
     }

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Models/Apprentice/ConfirmDetailsAndSendViewModel.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Models/Apprentice/ConfirmDetailsAndSendViewModel.cs
@@ -1,0 +1,19 @@
+﻿using SFA.DAS.Authorization.ModelBinding;
+using System;
+
+namespace SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice
+{
+    public class ConfirmDetailsAndSendViewModel : IAuthorizationContextModel
+    {
+        public string AccountHashedId { get; set; }
+        public string ApprenticeshipHashedId { get; set; }
+        public string ProviderName { get; set; }
+        public long ProviderId { get; set; }
+        public bool Edit { get; set; }
+        public int? NewStartMonth { get; set; }
+        public int? NewStartYear { get; set; }
+        public int? NewEndMonth { get; set; }
+        public int? NewEndYear { get; set; }
+        public int? NewPrice { get; set; }
+    }
+}

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Models/Apprentice/ConfirmDetailsAndSendViewModel.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Models/Apprentice/ConfirmDetailsAndSendViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using SFA.DAS.Authorization.ModelBinding;
-using System;
 
 namespace SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice
 {
@@ -9,6 +8,7 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice
         public string ApprenticeshipHashedId { get; set; }
         public string ProviderName { get; set; }
         public long ProviderId { get; set; }
+        public bool? EmployerWillAdd { get; set; }
         public bool Edit { get; set; }
         public int? NewStartMonth { get; set; }
         public int? NewStartYear { get; set; }

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Models/Apprentice/EmployerLedChangeOfProviderRequest.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Models/Apprentice/EmployerLedChangeOfProviderRequest.cs
@@ -13,7 +13,7 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice
         public long ApprenticeshipId { get; set; }
         public long ProviderId { get; set; }
         public string ProviderName { get; set; }
-
+        public bool? EmployerWillAdd { get; set; }
         public int? NewStartMonth { get; set; }
         public int? NewStartYear { get; set; }
         public int? NewEndMonth { get; set; }

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Models/Apprentice/EmployerLedChangeOfProviderRequest.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Models/Apprentice/EmployerLedChangeOfProviderRequest.cs
@@ -3,7 +3,7 @@ using SFA.DAS.Authorization.ModelBinding;
 
 namespace SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice
 {
-    public class WhatIsTheNewStartDateRequest : IAuthorizationContextModel
+    public class EmployerLedChangeOfProviderRequest : IAuthorizationContextModel
     {
         [FromRoute]
         public string AccountHashedId { get; set; }
@@ -12,7 +12,12 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice
 
         public long ApprenticeshipId { get; set; }
         public long ProviderId { get; set; }
-        public bool EmployerResponsibility { get; set; }
-    
+
+        public int? NewStartMonth { get; set; }
+        public int? NewStartYear { get; set; }
+        public int? NewEndMonth { get; set; }
+        public int? NewEndYear { get; set; }
+        public int? NewPrice { get; set; }
+        public bool? Edit { get; set; }
     }
 }

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Models/Apprentice/EmployerLedChangeOfProviderRequest.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Models/Apprentice/EmployerLedChangeOfProviderRequest.cs
@@ -12,6 +12,7 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice
 
         public long ApprenticeshipId { get; set; }
         public long ProviderId { get; set; }
+        public string ProviderName { get; set; }
 
         public int? NewStartMonth { get; set; }
         public int? NewStartYear { get; set; }

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Models/Apprentice/WhatIsTheNewStartDateRequest.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Models/Apprentice/WhatIsTheNewStartDateRequest.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.Authorization.ModelBinding;
+
+namespace SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice
+{
+    public class WhatIsTheNewStartDateRequest : IAuthorizationContextModel
+    {
+        [FromRoute]
+        public string AccountHashedId { get; set; }
+        [FromRoute]
+        public string ApprenticeshipHashedId { get; set; }
+
+        public long ApprenticeshipId { get; set; }
+        public long ProviderId { get; set; }
+        public bool EmployerResponsibility { get; set; }
+    
+    }
+}

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Models/Apprentice/WhatIsTheNewStartDateViewModel.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Models/Apprentice/WhatIsTheNewStartDateViewModel.cs
@@ -1,0 +1,24 @@
+﻿using SFA.DAS.Authorization.ModelBinding;
+using SFA.DAS.CommitmentsV2.Shared.Models;
+using System;
+
+namespace SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice
+{
+    public class WhatIsTheNewStartDateViewModel : IAuthorizationContextModel
+    {
+        public WhatIsTheNewStartDateViewModel()
+        {
+            NewStartDate = new MonthYearModel("");
+        }
+
+        public string AccountHashedId { get; set; }
+        public string ApprenticeshipHashedId { get; set; }
+        public string ProviderName { get; set; }
+        public long ProviderId { get; set; }
+        public DateTime StopDate { get; set; }
+        public MonthYearModel NewStartDate { get; }
+        public bool? Edit { get; set; }
+        public int? NewStartMonth { get => NewStartDate.Month; set => NewStartDate.Month = value; }
+        public int? NewStartYear { get => NewStartDate.Year; set => NewStartDate.Year = value; } 
+    }
+}

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Models/Apprentice/WhatIsTheNewStartDateViewModel.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Models/Apprentice/WhatIsTheNewStartDateViewModel.cs
@@ -13,15 +13,16 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice
 
         public string AccountHashedId { get; set; }
         public string ApprenticeshipHashedId { get; set; }
-        public string ProviderName { get; set; }
         public long ProviderId { get; set; }
+        public string ProviderName { get; set; }
+        public bool? EmployerWillAdd { get; set; }
         public DateTime StopDate { get; set; }
         public MonthYearModel NewStartDate { get; }
-        public bool Edit { get; set; }
         public int? NewStartMonth { get => NewStartDate.Month; set => NewStartDate.Month = value; }
         public int? NewStartYear { get => NewStartDate.Year; set => NewStartDate.Year = value; } 
         public int? NewEndMonth { get; }
         public int? NewEndYear { get; }
         public int? NewPrice { get; }
+        public bool Edit { get; set; }
     }
 }

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Models/Apprentice/WhatIsTheNewStartDateViewModel.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Models/Apprentice/WhatIsTheNewStartDateViewModel.cs
@@ -17,8 +17,11 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice
         public long ProviderId { get; set; }
         public DateTime StopDate { get; set; }
         public MonthYearModel NewStartDate { get; }
-        public bool? Edit { get; set; }
+        public bool Edit { get; set; }
         public int? NewStartMonth { get => NewStartDate.Month; set => NewStartDate.Month = value; }
         public int? NewStartYear { get => NewStartDate.Year; set => NewStartDate.Year = value; } 
+        public int? NewEndMonth { get; }
+        public int? NewEndYear { get; }
+        public int? NewPrice { get; }
     }
 }

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/RouteValues/RouteNames.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/RouteValues/RouteNames.cs
@@ -13,7 +13,7 @@
         public const string EnterNewTrainingProvider = "select-provider";
         public const string WhoWillEnterTheDetails = "who-will-enter-the-details";
         public const string WhatIsTheNewStartDate = "what-is-the-new-start-date";
-        public const string WhatIsTheNewStopDate = "what-is-the-new-stop-date";
+        public const string WhatIsTheNewEndDate = "what-is-the-new-end-date";
         public const string ConfirmDetailsAndSendRequest = "confirm-details-and-send-request";
         public const string SendRequestNewTrainingProvider = "send-request-new";
         public const string ChangeProviderRequestedConfirmation = "change-provider-requested";

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/RouteValues/RouteNames.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/RouteValues/RouteNames.cs
@@ -13,6 +13,8 @@
         public const string EnterNewTrainingProvider = "select-provider";
         public const string WhoWillEnterTheDetails = "who-will-enter-the-details";
         public const string WhatIsTheNewStartDate = "what-is-the-new-start-date";
+        public const string WhatIsTheNewStopDate = "what-is-the-new-stop-date";
+        public const string ConfirmDetailsAndSendRequest = "confirm-details-and-send-request";
         public const string SendRequestNewTrainingProvider = "send-request-new";
         public const string ChangeProviderRequestedConfirmation = "change-provider-requested";
         public const string ViewChanges = "view-changes";

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Validators/EditEndDateRequestValidator.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Validators/EditEndDateRequestValidator.cs
@@ -1,9 +1,5 @@
 ﻿using FluentValidation;
 using SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace SFA.DAS.EmployerCommitmentsV2.Web.Validators
 {

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Validators/EmployerLedChangeOfProviderRequestValidator.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Validators/EmployerLedChangeOfProviderRequestValidator.cs
@@ -1,0 +1,16 @@
+﻿using FluentValidation;
+using SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice;
+
+namespace SFA.DAS.EmployerCommitmentsV2.Web.Validators
+{
+    public class EmployerLedChangeOfProviderRequestValidator : AbstractValidator<EmployerLedChangeOfProviderRequest>
+    {
+        public EmployerLedChangeOfProviderRequestValidator()
+        {
+            RuleFor(x => x.AccountHashedId).NotEmpty();
+            RuleFor(x => x.ApprenticeshipHashedId).NotEmpty();
+
+            RuleFor(x => x.ProviderId).GreaterThan(0);
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Validators/WhatIsTheNewStartDateViewModelValidator.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Validators/WhatIsTheNewStartDateViewModelValidator.cs
@@ -24,7 +24,7 @@ namespace SFA.DAS.EmployerCommitmentsV2.Web.Validators
                 .When(z => z.NewStartMonth.HasValue && z.NewStartYear.HasValue);
             
             RuleFor(r => r.NewStartDate)
-                .Must((r, newStartDate) => newStartDate.IsGreaterThanOrEqualToDateTimeMonthYear(r.StopDate))
+                .Must((r, newStartDate) => newStartDate.IsEqualToOrAfterMonthYearOfDateTime(r.StopDate))
                 .WithMessage(r => $"The start date must be on or after {r.StopDate:MMMM yyyy}")
                 .When(r => r.NewStartDate.IsValid);
         }

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Validators/WhatIsTheNewStartDateViewModelValidator.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Validators/WhatIsTheNewStartDateViewModelValidator.cs
@@ -1,18 +1,32 @@
 ﻿using FluentValidation;
+using SFA.DAS.EmployerCommitmentsV2.Web.Extensions;
 using SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice;
+
 namespace SFA.DAS.EmployerCommitmentsV2.Web.Validators
 {
     public class WhatIsTheNewStartDateViewModelValidator : AbstractValidator<WhatIsTheNewStartDateViewModel>
     {
         public WhatIsTheNewStartDateViewModelValidator()
         {
-            RuleFor(r => r.AccountHashedId).NotEmpty();
-            RuleFor(r => r.ApprenticeshipHashedId).NotEmpty();
-            RuleFor(r => r.NewStartDate).Must(y => y.Month.HasValue && y.Year.HasValue).WithMessage("Enter the start date with the new training provider");
-            RuleFor(r => r.NewStartDate).Must(y => y.Year.HasValue).WithMessage("The start date must include a year");
-            RuleFor(r => r.NewStartDate).Must(y => y.Month.HasValue).WithMessage("The start date must include a month");
-            RuleFor(x => x.NewStartDate).Must(y => y.IsValid).WithMessage($"The start date must be a real date").When(z => z.NewStartDate.HasValue);
-
+            RuleFor(r => r.NewStartDate).Must((r, newStartDate) => r.NewStartMonth.HasValue && r.NewStartYear.HasValue)
+                .WithMessage("Enter the start date with the new training provider")
+                .Unless(r => r.NewStartYear.HasValue || r.NewStartMonth.HasValue);
+                       
+            RuleFor(r => r.NewStartDate).Must(y => y.Year.HasValue)
+                .WithMessage("The start date must include a year")
+                .When(r => r.NewStartMonth.HasValue);
+            
+            RuleFor(r => r.NewStartDate).Must(y => y.Month.HasValue).WithMessage("The start date must include a month")
+                .When(r => r.NewStartYear.HasValue);
+            
+            RuleFor(x => x.NewStartDate)
+                .Must(y => y.IsValid).WithMessage($"The start date must be a real date")
+                .When(z => z.NewStartMonth.HasValue && z.NewStartYear.HasValue);
+            
+            RuleFor(r => r.NewStartDate)
+                .Must((r, newStartDate) => newStartDate.IsGreaterThanOrEqualToDateTimeMonthYear(r.StopDate))
+                .WithMessage(r => $"The start date must be on or after {r.StopDate:MMMM yyyy}")
+                .When(r => r.NewStartDate.IsValid);
         }
     }
 }

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Validators/WhatIsTheNewStartDateViewModelValidator.cs
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Validators/WhatIsTheNewStartDateViewModelValidator.cs
@@ -1,0 +1,18 @@
+﻿using FluentValidation;
+using SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice;
+namespace SFA.DAS.EmployerCommitmentsV2.Web.Validators
+{
+    public class WhatIsTheNewStartDateViewModelValidator : AbstractValidator<WhatIsTheNewStartDateViewModel>
+    {
+        public WhatIsTheNewStartDateViewModelValidator()
+        {
+            RuleFor(r => r.AccountHashedId).NotEmpty();
+            RuleFor(r => r.ApprenticeshipHashedId).NotEmpty();
+            RuleFor(r => r.NewStartDate).Must(y => y.Month.HasValue && y.Year.HasValue).WithMessage("Enter the start date with the new training provider");
+            RuleFor(r => r.NewStartDate).Must(y => y.Year.HasValue).WithMessage("The start date must include a year");
+            RuleFor(r => r.NewStartDate).Must(y => y.Month.HasValue).WithMessage("The start date must include a month");
+            RuleFor(x => x.NewStartDate).Must(y => y.IsValid).WithMessage($"The start date must be a real date").When(z => z.NewStartDate.HasValue);
+
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Apprentice/ConfirmDetailsAndSendRequestPage.cshtml
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Apprentice/ConfirmDetailsAndSendRequestPage.cshtml
@@ -1,0 +1,8 @@
+﻿@using SFA.DAS.EmployerCommitmentsV2.Web.RouteValues
+@model SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice.ConfirmDetailsAndSendViewModel
+
+<p> Confirm details and send request page</p>
+
+
+<p> start date : @($"{new DateTime(Model.NewStartYear.Value, Model.NewStartMonth.Value, 1)}")</p>
+<a id="change-dates-link" class="govuk-link" href="@Url.RouteUrl(RouteNames.WhatIsTheNewStartDate, new { NewStartMonth = Model.NewStartMonth, NewStartYear = Model.NewStartYear, NewEndMonth = Model.NewEndMonth, NewEndYear = Model.NewEndYear, Price = Model.NewPrice, Edit = true})">Change start date</a>

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Apprentice/WhatIsTheNewEndDate.cshtml
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Apprentice/WhatIsTheNewEndDate.cshtml
@@ -1,0 +1,5 @@
+﻿
+@*
+    For more information on enabling MVC for empty projects, visit http://go.microsoft.com/fwlink/?LinkID=397860
+*@
+<p> End date </p>

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Apprentice/WhatIsTheNewStartDate.cshtml
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Apprentice/WhatIsTheNewStartDate.cshtml
@@ -1,4 +1,5 @@
-﻿@model SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice.WhatIsTheNewStartDateViewModel
+﻿@using SFA.DAS.CommitmentsV2.Shared.Extensions
+@model SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice.WhatIsTheNewStartDateViewModel
 
 @{
     ViewData["Title"] = "What is the start date with the new training provider? - Apprenticeship service - GOV.UK";
@@ -17,7 +18,7 @@
             <input type="hidden" asp-for="NewEndYear" />
             <input type="hidden" asp-for="NewPrice" />
 
-            <div class="govuk-form-group">
+            <div class="govuk-form-group @Html.AddClassIfPropertyInError(x => x.NewStartDate,  "govuk-form-group--error")">
                 <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-padding-bottom-6">
                         <h1 class="govuk-fieldset__heading">

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Apprentice/WhatIsTheNewStartDate.cshtml
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Apprentice/WhatIsTheNewStartDate.cshtml
@@ -11,6 +11,7 @@
         <form method="post">
             @Html.AntiForgeryToken()
             <input type="hidden" asp-for="ProviderId" />
+            <input type="hidden" asp-for="ProviderName" />
             <input type="hidden" asp-for="StopDate" />
             <input type="hidden" asp-for="NewEndMonth" />
             <input type="hidden" asp-for="NewEndYear" />
@@ -36,13 +37,13 @@
                         <div class="govuk-date-input__item">
                             <div class="govuk-form-group">
                                 <label asp-for="NewStartMonth" class="govuk-label govuk-date-input__label">Month</label>
-                                <input asp-for="NewStartMonth" min="1" max="12" class="govuk-input govuk-date-input__input govuk-input--width-2" type="number">
+                                <input asp-for="NewStartMonth" class="govuk-input govuk-date-input__input govuk-input--width-2" type="number">
                             </div>
                         </div>
                         <div class="govuk-date-input__item">
                             <div class="govuk-form-group">
                                 <label asp-for="NewStartYear" class="govuk-label govuk-date-input__label">Year</label>
-                                <input asp-for="NewStartYear" min="1900" max="9999" class="govuk-input govuk-date-input__input govuk-input--width-4" type="number">
+                                <input asp-for="NewStartYear" class="govuk-input govuk-date-input__input govuk-input--width-4" type="number">
                             </div>
                         </div>
                     </div>

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Apprentice/WhatIsTheNewStartDate.cshtml
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Apprentice/WhatIsTheNewStartDate.cshtml
@@ -11,8 +11,10 @@
         <form method="post">
             @Html.AntiForgeryToken()
             <input type="hidden" asp-for="ProviderId" />
-            <input type="hidden" asp-for="AccountHashedId" />
-            <input type="hidden" asp-for="ApprenticeshipHashedId" />
+            <input type="hidden" asp-for="StopDate" />
+            <input type="hidden" asp-for="NewEndMonth" />
+            <input type="hidden" asp-for="NewEndYear" />
+            <input type="hidden" asp-for="NewPrice" />
 
             <div class="govuk-form-group">
                 <fieldset class="govuk-fieldset">
@@ -23,7 +25,7 @@
                     </legend>
 
                     <p class="govuk-body">
-                        This date must be on or after the stop date @(Model.StopDate)
+                        This date must be on or after the stop date (@(Model.StopDate.ToString("MMMM yyyy")))
                     </p>
 
                     <span class="govuk-hint">
@@ -44,8 +46,6 @@
                             </div>
                         </div>
                     </div>
-
-
                 </fieldset>
             </div>
 

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Apprentice/WhatIsTheNewStartDate.cshtml
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Apprentice/WhatIsTheNewStartDate.cshtml
@@ -1,6 +1,60 @@
-﻿
-@*
-    Placeholder for CON-2519
-*@
+﻿@model SFA.DAS.EmployerCommitmentsV2.Web.Models.Apprentice.WhatIsTheNewStartDateViewModel
 
-<p> Enter start date </p>
+@{
+    ViewData["Title"] = "What is the start date with the new training provider? - Apprenticeship service - GOV.UK";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <partial name="_ValidationSummary" />
+
+        <form method="post">
+            @Html.AntiForgeryToken()
+            <input type="hidden" asp-for="ProviderId" />
+            <input type="hidden" asp-for="AccountHashedId" />
+            <input type="hidden" asp-for="ApprenticeshipHashedId" />
+
+            <div class="govuk-form-group">
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-padding-bottom-6">
+                        <h1 class="govuk-fieldset__heading">
+                            What is the start date with @(Model.ProviderName)?
+                        </h1>
+                    </legend>
+
+                    <p class="govuk-body">
+                        This date must be on or after the stop date @(Model.StopDate)
+                    </p>
+
+                    <span class="govuk-hint">
+                        For example, 04 2020
+                    </span>
+
+                    <div class="govuk-date-input">
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <label asp-for="NewStartMonth" class="govuk-label govuk-date-input__label">Month</label>
+                                <input asp-for="NewStartMonth" min="1" max="12" class="govuk-input govuk-date-input__input govuk-input--width-2" type="number">
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <label asp-for="NewStartYear" class="govuk-label govuk-date-input__label">Year</label>
+                                <input asp-for="NewStartYear" min="1900" max="9999" class="govuk-input govuk-date-input__input govuk-input--width-4" type="number">
+                            </div>
+                        </div>
+                    </div>
+
+
+                </fieldset>
+            </div>
+
+            <button class="govuk-button" type="submit"> Continue </button>
+        </form>
+    </div>
+</div>
+
+@section Back
+{
+    <div class="das-js-back-link"></div>
+}

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Apprentice/WhatIsTheNewStartDate.cshtml
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Apprentice/WhatIsTheNewStartDate.cshtml
@@ -13,6 +13,7 @@
             @Html.AntiForgeryToken()
             <input type="hidden" asp-for="ProviderId" />
             <input type="hidden" asp-for="ProviderName" />
+            <input type="hidden" asp-for="EmployerWillAdd" />
             <input type="hidden" asp-for="StopDate" />
             <input type="hidden" asp-for="NewEndMonth" />
             <input type="hidden" asp-for="NewEndYear" />
@@ -26,7 +27,7 @@
                         </h1>
                     </legend>
 
-                    <p class="govuk-body">
+                    <p class="govuk-body" id="help-text">
                         This date must be on or after the stop date (@(Model.StopDate.ToString("MMMM yyyy")))
                     </p>
 
@@ -38,20 +39,20 @@
                         <div class="govuk-date-input__item">
                             <div class="govuk-form-group">
                                 <label asp-for="NewStartMonth" class="govuk-label govuk-date-input__label">Month</label>
-                                <input asp-for="NewStartMonth" class="govuk-input govuk-date-input__input govuk-input--width-2" type="number">
+                                <input asp-for="NewStartMonth" class="govuk-input govuk-date-input__input govuk-input--width-2" type="number" id="new-start-month">
                             </div>
                         </div>
                         <div class="govuk-date-input__item">
                             <div class="govuk-form-group">
                                 <label asp-for="NewStartYear" class="govuk-label govuk-date-input__label">Year</label>
-                                <input asp-for="NewStartYear" class="govuk-input govuk-date-input__input govuk-input--width-4" type="number">
+                                <input asp-for="NewStartYear" class="govuk-input govuk-date-input__input govuk-input--width-4" type="number" id="new-start-year">
                             </div>
                         </div>
                     </div>
                 </fieldset>
             </div>
 
-            <button class="govuk-button" type="submit"> Continue </button>
+            <button class="govuk-button" type="submit" id="continue-button"> Continue </button>
         </form>
     </div>
 </div>

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Apprentice/WhoWillEnterTheDetails.cshtml
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Apprentice/WhoWillEnterTheDetails.cshtml
@@ -37,8 +37,8 @@
 
                     <div class="govuk-radios">
                         <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" type="radio" id="EmployerWillAdd-yes" name="EmployerWillAdd" value="true">
-                            <label class="govuk-label govuk-radios__label" for="EmployerWillAdd-yes"> I'll add them now</label>
+                            <input class="govuk-radios__input" type="radio" id="EmployerWillAdd" name="EmployerWillAdd" value="true">
+                            <label class="govuk-label govuk-radios__label" for="EmployerWillAdd"> I'll add them now</label>
                         </div>
 
                         <div class="govuk-radios__item">

--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Apprentice/WhoWillEnterTheDetails.cshtml
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Apprentice/WhoWillEnterTheDetails.cshtml
@@ -13,6 +13,8 @@
         <form method="post">
             @Html.AntiForgeryToken()
             <input type="hidden" asp-for="ProviderId" />
+            <input type="hidden" asp-for="ProviderName" />
+
 
             <div class="govuk-form-group @Html.AddClassIfPropertyInError(x => x.EmployerWillAdd,  "govuk-form-group--error")">
                 <fieldset class="govuk-fieldset">


### PR DESCRIPTION
I have created the WhatIsTheNewStartDate page and added two WIP pages to allow me to fully test the 'submit answer' and 'change + update answer' behaviour of this page. The WhatIsTheNewEndDate page will be completed in CON-2518 and the ConfirmDetailsAndSendRequest page will be completed in CON-2521. 

I have also created the EmployerLedChangeOfProviderRequest model and included nullable properties for each of the required answers for the journey so that we can easily add answers from each page and return to change any answer from the 'confirm and send page'. This request object also contains an Edit property which should be set to true when returning to update an answer. This will allow the POST action to redirect back to the 'confirm and send page' instead of the next page in the journey.

Finally, I have added an extension method for the MonthYearModel that will enable us to compare a MonthYear to a DateTime in the ViewModel validator. The new start date must be in the same month or after the stop date of the apprenticeship but as we are only collecting the new month or year this method protects us against potential situations where the stop date contains a day or time where comparing NewStartDate >= StopDate would lead to the validator returning a false error.
