### PR TITLE
MAP-186 Fixed broken link on pause apprenticeship page 

### DIFF
--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Apprentice/PauseApprenticeship.cshtml
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Apprentice/PauseApprenticeship.cshtml
@@ -13,6 +13,8 @@
     pageId = "apprentice-paused";
     pageHeading = "Pause apprenticeship";
 
+    string financeDataLink = LinkGenerator.FinanceLink($"accounts/{Model.AccountHashedId}/finance/{DateTime.Now.Year}/{DateTime.Now.Month}");
+
     ViewBag.Title = pageTitle;
     ViewBag.PageId = pageId;
     ViewBag.Section = "apprentices";
@@ -34,7 +36,7 @@
             </p>
 
             <p class="govuk-body">
-                <a class="govuk-link" target="_blank" href="financeDataLink" id="view-transactions-link">View your transactions</a> to confirm all payments are up-to-date before pausing.
+                <a class="govuk-link" target="_blank" href="@financeDataLink" id="view-transactions-link">View your transactions</a> to confirm all payments are up-to-date before pausing.
             </p>
 
             <p class="govuk-body">You can return and resume the apprenticeship at any time.</p>


### PR DESCRIPTION
On this [page](https://github.com/SkillsFundingAgency/das-employercommitments-v2/blob/MAP-186-broken-link-pause-apprenticeship/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Apprentice), I added the following variable declaration;

```
string financeDataLink = LinkGenerator.FinanceLink($"accounts/{Model.AccountHashedId}/finance/{DateTime.Now.Year}/{DateTime.Now.Month}");
``` 