### PR TITLE
CON-4885 adding title to ConfirmDelete page

### DIFF
--- a/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Cohort/ConfirmDelete.cshtml
+++ b/src/SFA.DAS.EmployerCommitmentsV2.Web/Views/Cohort/ConfirmDelete.cshtml
@@ -3,6 +3,7 @@
 @model SFA.DAS.EmployerCommitmentsV2.Web.Models.Cohort.ConfirmDeleteViewModel
 
 @{
+    ViewBag.Title = "Confirm Delete";
     ViewBag.GaData.Vpv = "/unapproved/delete";
     ViewBag.GaData.Org = Model.LegalEntityName;
 }


### PR DESCRIPTION
Accessibility test: EAS - Document title must not be blank.
Page affected:
*Confirm deletion